### PR TITLE
Only show enum member's value

### DIFF
--- a/enum_tools/autoenum.py
+++ b/enum_tools/autoenum.py
@@ -502,7 +502,7 @@ class EnumMemberDocumenter(AttributeDocumenter):
 
 					# Workaround for https://github.com/sphinx-doc/sphinx/issues/9272
 					# which broke Enum displays in 4.1.0
-					objrepr = memory_address_re.sub('', repr(self.object)).replace('\n', ' ')
+					objrepr = memory_address_re.sub('', repr(self.object.value)).replace('\n', ' ')
 					self.add_line(f'   :value: {objrepr}', self.get_sourcename())
 
 


### PR DESCRIPTION
Resolves #34. IMO there's no reason why anyone would want the repr of the full object, so I just changed it to only show the value, but I can add an option if desired