### PR TITLE
Use conda-forge channel as source for installation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -143,18 +143,9 @@ To install with ``pip``:
 
 To install with ``conda``:
 
-	* First add the required channels
+.. code-block:: bash
 
-	.. code-block:: bash
-
-		$ conda config --add channels https://conda.anaconda.org/conda-forge
-		$ conda config --add channels https://conda.anaconda.org/domdfcoding
-
-	* Then install
-
-	.. code-block:: bash
-
-		$ conda install enum_tools
+	$ conda install -c conda-forge enum_tools
 
 .. end installation
 


### PR DESCRIPTION
I think many conda packages are available at conda-forge nowadays so that maybe it could even be the default way of installing this tool in the future? This, of course, would also be an option for all other packages that are available on conda-forge now.