### PR TITLE
Pin sphinx<9 and bump to 0.13.1

### DIFF
--- a/__pkginfo__.py
+++ b/__pkginfo__.py
@@ -3,6 +3,6 @@
 __all__ = ["extras_require"]
 
 extras_require = {
-		"sphinx": ["sphinx>=3.4.0", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0"],
-		"all": ["sphinx>=3.4.0", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0"]
+		"sphinx": ["sphinx>=3.4.0,<9", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0"],
+		"all": ["sphinx>=3.4.0,<9", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0"]
 		}

--- a/enum_tools/__init__.py
+++ b/enum_tools/__init__.py
@@ -33,7 +33,7 @@ from enum_tools.documentation import DocumentedEnum, document_enum, document_mem
 __author__: str = "Dominic Davis-Foster"
 __copyright__: str = "2020 Dominic Davis-Foster"
 __license__: str = "GNU Lesser General Public License v3 or later (LGPLv3+)"
-__version__: str = "0.13.0"
+__version__: str = "0.13.1"
 __email__: str = "dominic@davis-foster.co.uk"
 
 __all__ = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "whey"
 
 [project]
 name = "enum-tools"
-version = "0.13.0"
+version = "0.13.1"
 description = "Tools to expand Python's enum module."
 readme = "README.rst"
 keywords = [ "documentation", "enum", "sphinx", "sphinx-extension",]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,8 +24,8 @@ Homepage = "https://github.com/domdfcoding/enum_tools"
 Documentation = "https://enum-tools.readthedocs.io/en/latest"
 
 [project.optional-dependencies]
-sphinx = [ "sphinx>=3.4.0", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0",]
-all = [ "sphinx>=3.4.0", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0",]
+sphinx = [ "sphinx<9,>=3.4.0", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0",]
+all = [ "sphinx<9,>=3.4.0", "sphinx-jinja2-compat>=0.1.1", "sphinx-toolbox>=2.16.0",]
 
 [tool.whey]
 base-classifiers = [

--- a/repo_helper.yml
+++ b/repo_helper.yml
@@ -151,7 +151,7 @@ keywords:
 
 extras_require:
   sphinx:
-   - sphinx>=3.4.0
+   - sphinx>=3.4.0,<9
    - sphinx-toolbox>=2.16.0
    - sphinx-jinja2-compat>=0.1.1
 

--- a/repo_helper.yml
+++ b/repo_helper.yml
@@ -4,7 +4,7 @@ modname: enum_tools
 copyright_years: "2020-2022"
 author: "Dominic Davis-Foster"
 email: "dominic@davis-foster.co.uk"
-version: "0.13.0"
+version: "0.13.1"
 username: "domdfcoding"
 license: 'LGPLv3+'
 short_desc: "Tools to expand Python's enum module."


### PR DESCRIPTION
## Summary
- `enum_tools.autoenum` is currently incompatible with Sphinx 9.0.0 (see #118).
- Pin `sphinx<9` in the `sphinx` and `all` extras so `pip install enum-tools[sphinx]` continues to resolve a working Sphinx until autoenum is updated for the Sphinx 9 API.
- Bump version `0.13.0` → `0.13.1` so the cap can be released as a patch.

Fixes #118 (workaround; full Sphinx 9 support remains a separate effort).

## Changes
Two commits:
1. `Pin sphinx<9 to avoid autoenum incompatibility` — adds the upper bound in `repo_helper.yml`, `pyproject.toml`, and `__pkginfo__.py`.
2. `Bump version 0.13.0 -> 0.13.1` — updates `repo_helper.yml`, `pyproject.toml`, and `enum_tools/__init__.py`.

## Test plan
- [x] `pip install -e .[sphinx]` in a clean venv resolves a Sphinx <9 release (no Sphinx 9 prereleases pulled).
- [ ] Existing CI green on the supported Sphinx matrix (3.4 – 8.2); no matrix changes are needed since Sphinx 9 was never listed.
- [x] `python -c "import enum_tools; print(enum_tools.__version__)"` reports `0.13.1`.

## Notes for maintainer
- Edits were made to both `repo_helper.yml` (source of truth) and the generated `pyproject.toml` / `__pkginfo__.py`, so the wheel built from this tip ships the cap without requiring a `repo-helper` regeneration first. A subsequent `repo-helper` run should be a no-op on these specific lines.
- A linter normalized `sphinx>=3.4.0,<9` to `sphinx<9,>=3.4.0` in `pyproject.toml`; functionally equivalent under PEP 508.
- Suggested GitHub Release body for v0.13.1:
  > ### Bug Fixes
  > - Pinned `sphinx < 9` in the `sphinx` and `all` extras. `enum_tools.autoenum` currently fails with Sphinx >= 9.0.0; see #118.

🤖 Generated with [Claude Code](https://claude.com/claude-code)