### PR TITLE
Construct autoenum's logger locally instead of importing from sphinx.…

### DIFF
--- a/enum_tools/autoenum.py
+++ b/enum_tools/autoenum.py
@@ -73,11 +73,16 @@ from sphinx.ext.autodoc import (  # nodep
 		ClassLevelDocumenter,
 		Documenter,
 		ObjectMember,
-		logger
 		)
 from sphinx.locale import _  # nodep
 from sphinx.pycode import ModuleAnalyzer  # nodep
+from sphinx.util import logging as sphinx_logging  # nodep
 from sphinx.util.inspect import memory_address_re, safe_getattr  # nodep
+
+# sphinx.ext.autodoc.logger was dropped from the module's public surface in
+# Sphinx 9 when autodoc was rewritten. Construct our own; getLogger has been
+# available in sphinx.util.logging since Sphinx 1.6.
+logger = sphinx_logging.getLogger(__name__)
 from sphinx_toolbox.more_autodoc import ObjectMembers  # nodep
 from sphinx_toolbox.more_autodoc.typehints import format_annotation  # nodep
 from sphinx_toolbox.utils import add_fallback_css_class  # nodep

--- a/enum_tools/autoenum.py
+++ b/enum_tools/autoenum.py
@@ -72,7 +72,7 @@ from sphinx.ext.autodoc import (  # nodep
 		ClassDocumenter,
 		ClassLevelDocumenter,
 		Documenter,
-		ObjectMember,
+		ObjectMember
 		)
 from sphinx.locale import _  # nodep
 from sphinx.pycode import ModuleAnalyzer  # nodep
@@ -83,6 +83,7 @@ from sphinx.util.inspect import memory_address_re, safe_getattr  # nodep
 # Sphinx 9 when autodoc was rewritten. Construct our own; getLogger has been
 # available in sphinx.util.logging since Sphinx 1.6.
 logger = sphinx_logging.getLogger(__name__)
+# 3rd party
 from sphinx_toolbox.more_autodoc import ObjectMembers  # nodep
 from sphinx_toolbox.more_autodoc.typehints import format_annotation  # nodep
 from sphinx_toolbox.utils import add_fallback_css_class  # nodep

--- a/enum_tools/autoenum.py
+++ b/enum_tools/autoenum.py
@@ -78,12 +78,6 @@ from sphinx.locale import _  # nodep
 from sphinx.pycode import ModuleAnalyzer  # nodep
 from sphinx.util import logging as sphinx_logging  # nodep
 from sphinx.util.inspect import memory_address_re, safe_getattr  # nodep
-
-# sphinx.ext.autodoc.logger was dropped from the module's public surface in
-# Sphinx 9 when autodoc was rewritten. Construct our own; getLogger has been
-# available in sphinx.util.logging since Sphinx 1.6.
-logger = sphinx_logging.getLogger(__name__)
-# 3rd party
 from sphinx_toolbox.more_autodoc import ObjectMembers  # nodep
 from sphinx_toolbox.more_autodoc.typehints import format_annotation  # nodep
 from sphinx_toolbox.utils import add_fallback_css_class  # nodep
@@ -100,6 +94,11 @@ from enum_tools import __version__, documentation
 from enum_tools.utils import get_base_object, is_enum, is_flag
 
 __all__ = ["EnumDocumenter", "EnumMemberDocumenter", "setup", "FlagDocumenter", "PyEnumXRefRole"]
+
+# sphinx.ext.autodoc.logger was dropped from the module's public surface in
+# Sphinx 9 when autodoc was rewritten. Construct our own; getLogger has been
+# available in sphinx.util.logging since Sphinx 1.6.
+logger = sphinx_logging.getLogger(__name__)
 
 documentation.INTERACTIVE = True
 


### PR DESCRIPTION
…ext.autodoc

Sphinx 9 dropped the re-exported `logger` symbol from `sphinx.ext.autodoc` when the module was rewritten (sphinx-doc/sphinx#13751, #14089). Switch to `sphinx.util.logging.getLogger(__name__)`, which has been available since Sphinx 1.6 and produces an equivalent logger.

This is the first error reported in #118. Note that full Sphinx 9 support is still blocked on sphinx-toolbox/sphinx-toolbox#201, which is the same bug in a runtime dependency. Once that lands, the sphinx<9 cap added in 121ac05 can be lifted.

Refs: https://github.com/domdfcoding/enum_tools/issues/118
Refs: https://github.com/sphinx-toolbox/sphinx-toolbox/issues/201